### PR TITLE
Update traits in Cargo.toml and src/approx_floats.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,8 @@ readme = "README.md"
 keywords = ["algebra", "ring", "field", "group", "lattice"]
 categories = ["mathematics", "science"]
 
+[features]
+float_fallback=[]
+
 [dependencies]
 num = "0.3"

--- a/src/approx_floats.rs
+++ b/src/approx_floats.rs
@@ -24,7 +24,7 @@ pub const F64: ApproxFloats<f64> = ApproxFloats {
 pub struct ApproxFloats<E> {
     phantom: PhantomData<E>,
 }
-
+#[cfg(not(feature="float_fallback"))]
 impl<E> Domain for ApproxFloats<E>
 where
     E: Float + Debug + Zero + One + From<isize>,
@@ -39,7 +39,7 @@ where
         elem1 == elem2
     }
 }
-
+#[cfg(not(feature="float_fallback"))]
 impl<E> Semigroup for ApproxFloats<E>
 where
     E: Float + Debug + Zero + One + From<isize>,
@@ -50,7 +50,7 @@ where
         elem
     }
 }
-
+#[cfg(not(feature="float_fallback"))]
 impl<E> Monoid for ApproxFloats<E>
 where
     E: Float + Debug + Zero + One + From<isize>,
@@ -68,7 +68,7 @@ where
         }
     }
 }
-
+#[cfg(not(feature="float_fallback"))]
 impl<E> AbelianGroup for ApproxFloats<E>
 where
     E: Float + Debug + Zero + One + From<isize>,
@@ -104,9 +104,9 @@ where
         num * *elem
     }
 }
-
+#[cfg(not(feature="float_fallback"))]
 impl<E> UnitaryRing for ApproxFloats<E> where E: Float + Debug + Zero + One + From<isize> {}
-
+#[cfg(not(feature="float_fallback"))]
 impl<E> Field for ApproxFloats<E>
 where
     E: Float + Debug + Zero + One + From<isize>,
@@ -122,7 +122,7 @@ where
         elem
     }
 }
-
+#[cfg(not(feature="float_fallback"))]
 impl<E> PartialOrder for ApproxFloats<E>
 where
     E: Float + Debug + Zero + One + From<isize>,
@@ -131,7 +131,7 @@ where
         *elem1 <= *elem2
     }
 }
-
+#[cfg(not(feature="float_fallback"))]
 impl<E> Lattice for ApproxFloats<E>
 where
     E: Float + Debug + Zero + One + From<isize>,
@@ -144,5 +144,252 @@ where
         elem1.max(*elem2)
     }
 }
-
+#[cfg(not(feature="float_fallback"))]
 impl<E> DistributiveLattice for ApproxFloats<E> where E: Float + Debug + Zero + One + From<isize> {}
+
+
+#[cfg(feature="float_fallback")]
+impl Domain for ApproxFloats<f64>
+{
+    type Elem = f64;
+
+    fn contains(&self, elem: &Self::Elem) -> bool {
+        elem.is_finite()
+    }
+
+    fn equals(&self, elem1: &Self::Elem, elem2: &Self::Elem) -> bool {
+        elem1 == elem2
+    }
+}
+
+#[cfg(feature="float_fallback")]
+impl Semigroup for ApproxFloats<f64>
+{
+    fn mul(&self, elem1: &Self::Elem, elem2: &Self::Elem) -> Self::Elem {
+        let elem = *elem1 * *elem2;
+        assert!(elem.is_finite());
+        elem
+    }
+}
+
+#[cfg(feature="float_fallback")]
+impl Monoid for ApproxFloats<f64>
+{
+    fn one(&self) -> Self::Elem {
+        One::one()
+    }
+
+    fn try_inv(&self, elem: &Self::Elem) -> Option<Self::Elem> {
+        let elem = self.one() / *elem;
+        if elem.is_finite() {
+            Some(elem)
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(feature="float_fallback")]
+impl AbelianGroup for ApproxFloats<f64>
+{
+    fn zero(&self) -> Self::Elem {
+        Zero::zero()
+    }
+
+    fn is_zero(&self, elem: &Self::Elem) -> bool {
+        elem.is_zero()
+    }
+
+    fn neg(&self, elem: &Self::Elem) -> Self::Elem {
+        let elem = -*elem;
+        assert!(elem.is_finite());
+        elem
+    }
+
+    fn add(&self, elem1: &Self::Elem, elem2: &Self::Elem) -> Self::Elem {
+        let elem = *elem1 + *elem2;
+        assert!(elem.is_finite());
+        elem
+    }
+
+    fn sub(&self, elem1: &Self::Elem, elem2: &Self::Elem) -> Self::Elem {
+        let elem = *elem1 - *elem2;
+        assert!(elem.is_finite());
+        elem
+    }
+
+    fn times(&self, num: isize, elem: &Self::Elem) -> Self::Elem {
+        let num: Self::Elem = num as f64;
+        num * *elem
+    }
+}
+
+#[cfg(feature="float_fallback")]
+impl UnitaryRing for ApproxFloats<f64>{}
+
+#[cfg(feature="float_fallback")]
+impl Field for ApproxFloats<f64>
+{
+    fn inv(&self, elem: &Self::Elem) -> Self::Elem {
+        self.div(&self.one(), elem)
+    }
+
+    fn div(&self, elem1: &Self::Elem, elem2: &Self::Elem) -> Self::Elem {
+        assert!(!self.is_zero(elem2));
+        let elem = *elem1 / *elem2;
+        assert!(elem.is_finite());
+        elem
+    }
+}
+
+#[cfg(feature="float_fallback")]
+impl PartialOrder for ApproxFloats<f64>
+{
+    fn leq(&self, elem1: &Self::Elem, elem2: &Self::Elem) -> bool {
+        *elem1 <= *elem2
+    }
+}
+
+#[cfg(feature="float_fallback")]
+impl Lattice for ApproxFloats<f64>
+{
+    fn meet(&self, elem1: &Self::Elem, elem2: &Self::Elem) -> Self::Elem {
+        elem1.min(*elem2)
+    }
+
+    fn join(&self, elem1: &Self::Elem, elem2: &Self::Elem) -> Self::Elem {
+        elem1.max(*elem2)
+    }
+}
+
+#[cfg(feature="float_fallback")]
+impl DistributiveLattice for ApproxFloats<f64>{}
+
+
+#[cfg(feature="float_fallback")]
+impl Domain for ApproxFloats<f32>
+{
+    type Elem = f32;
+
+    fn contains(&self, elem: &Self::Elem) -> bool {
+        elem.is_finite()
+    }
+
+    fn equals(&self, elem1: &Self::Elem, elem2: &Self::Elem) -> bool {
+        elem1 == elem2
+    }
+}
+
+#[cfg(feature="float_fallback")]
+impl Semigroup for ApproxFloats<f32>
+{
+    fn mul(&self, elem1: &Self::Elem, elem2: &Self::Elem) -> Self::Elem {
+        let elem = *elem1 * *elem2;
+        assert!(elem.is_finite());
+        elem
+    }
+}
+
+#[cfg(feature="float_fallback")]
+impl Monoid for ApproxFloats<f32>
+{
+    fn one(&self) -> Self::Elem {
+        One::one()
+    }
+
+    fn try_inv(&self, elem: &Self::Elem) -> Option<Self::Elem> {
+        let elem = self.one() / *elem;
+        if elem.is_finite() {
+            Some(elem)
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(feature="float_fallback")]
+impl AbelianGroup for ApproxFloats<f32>
+{
+    fn zero(&self) -> Self::Elem {
+        Zero::zero()
+    }
+
+    fn is_zero(&self, elem: &Self::Elem) -> bool {
+        elem.is_zero()
+    }
+
+    fn neg(&self, elem: &Self::Elem) -> Self::Elem {
+        let elem = -*elem;
+        assert!(elem.is_finite());
+        elem
+    }
+
+    fn add(&self, elem1: &Self::Elem, elem2: &Self::Elem) -> Self::Elem {
+        let elem = *elem1 + *elem2;
+        assert!(elem.is_finite());
+        elem
+    }
+
+    fn sub(&self, elem1: &Self::Elem, elem2: &Self::Elem) -> Self::Elem {
+        let elem = *elem1 - *elem2;
+        assert!(elem.is_finite());
+        elem
+    }
+
+    fn times(&self, num: isize, elem: &Self::Elem) -> Self::Elem {
+        let num: Self::Elem = num as f32;
+        num * *elem
+    }
+}
+
+#[cfg(feature="float_fallback")]
+impl UnitaryRing for ApproxFloats<f32>{}
+
+#[cfg(feature="float_fallback")]
+impl Field for ApproxFloats<f32>
+{
+    fn inv(&self, elem: &Self::Elem) -> Self::Elem {
+        self.div(&self.one(), elem)
+    }
+
+    fn div(&self, elem1: &Self::Elem, elem2: &Self::Elem) -> Self::Elem {
+        assert!(!self.is_zero(elem2));
+        let elem = *elem1 / *elem2;
+        assert!(elem.is_finite());
+        elem
+    }
+}
+
+#[cfg(feature="float_fallback")]
+impl PartialOrder for ApproxFloats<f32>
+{
+    fn leq(&self, elem1: &Self::Elem, elem2: &Self::Elem) -> bool {
+        *elem1 <= *elem2
+    }
+}
+#[cfg(feature="float_fallback")]
+impl Lattice for ApproxFloats<f32>
+{
+    fn meet(&self, elem1: &Self::Elem, elem2: &Self::Elem) -> Self::Elem {
+        elem1.min(*elem2)
+    }
+
+    fn join(&self, elem1: &Self::Elem, elem2: &Self::Elem) -> Self::Elem {
+        elem1.max(*elem2)
+    }
+}
+#[cfg(feature="float_fallback")]
+impl DistributiveLattice for ApproxFloats<f32>{}
+
+#[cfg(test)]
+mod tests {
+   use super::*;
+    #[test]
+    #[cfg(feature="float_fallback")]
+    fn assertions() {
+       assert_eq!(0.0,F64.zero());
+       assert_eq!(1.0,F64.one());
+       assert_eq!(2.0,F64.int(2));
+    }
+
+}


### PR DESCRIPTION
The purpose of this pull request is to address a current limitation in the use of `ApproxFloats` within the library. (closes #1 ) As it stands, `ApproxFloats<f64>` cannot be used as a field due to the lack of `From<isize>` implementation for floats in Rust's current state.
 
Given that it's uncertain when or if this feature will be added in future Rust releases, the proposed changes offer a workaround for those needing to use this package in the present moment.
 
The implemented solution introduces conditional compilation based on the "float_fallback" feature. It allows for different implementations of the traits depending on whether this feature is enabled or disabled. More specifically, it offers an implementation for `Domain for ApproxFloats<f64>` when the "float_fallback" feature is activated.
 
Crucially, this implementation does not interfere with the existing structure. The original trait `Domain for ApproxFloats<E>` where `E: Float + Debug + Zero + One + From<isize>` remains untouched and functional when the "float_fallback" feature is not activated, preserving backward compatibility.

This adjustment enhances the flexibility and usability of the library, making it possible to use `ApproxFloats<f64>` as a field in the present state of Rust. While we hope that Rust might support `From<isize>` for floats in the future, this change serves as an effective workaround for immediate needs.